### PR TITLE
Auto-creation of Outline groups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ OUTLINE_WEBHOOK_SECRET=ol_whs_EXAMPLE
 
 # Debug logs (True/False)
 DEBUG=False
+
+# Auto-create missing groups in Outline (True/False)
+AUTO_CREATE_GROUPS=False

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ Outline groups that are named the same as Authentik groups will be linked togeth
 
 This connector listens for `users.signin` webhook events from Outline. Once a user signs into Outline, this connector will check for matching groups, and add/remove the user to those groups accordingly.
 
+## Features
+
+### Group Synchronization
+When a user signs in to Outline, the connector automatically syncs their group memberships between Authentik and Outline.
+
+### Auto-Creation of Groups
+When the `AUTO_CREATE_GROUPS` environment variable is set to `True`, the connector will automatically create Outline groups that:
+- Exist in Authentik but don't yet exist in Outline
+- The signing-in user is a member of
+
+This on-demand approach creates groups only when needed rather than creating all groups at once, optimizing resources and keeping your Outline workspace clean.
+
 ## Requirements
 - Outline API key
 - Authentik API key
@@ -45,18 +57,27 @@ The connector can be deployed with Docker Compose for quick and easy setup.
 4. Use a reverse proxy to proxy the connector to a subdomain with HTTPS.
 
 ## Manual Setup
-1. Install requirements.
+1. Create and activate a virtual environment.
 ```sh
-pip3 install -r requirements.txt
+python3 -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
 ```
-2. Copy the environment configuration, and fill it in with your Authentik and Outline configuration.
+
+2. Install requirements.
+```sh
+pip install -r requirements.txt
+```
+
+3. Copy the environment configuration, and fill it in with your Authentik and Outline configuration.
 ```sh
 cp .env.example .env
 nano .env
 ```
 
-3. Start the connector.
+4. Start the connector.
 ```sh
 fastapi run connect.py --port 8430
 ```
-4. Use a reverse proxy to proxy the connector to a subdomain with HTTPS.
+5. Use a reverse proxy to proxy the connector to a subdomain with HTTPS.
+
+**Note:** Always activate the virtual environment (`source venv/bin/activate`) before running the connector or installing new dependencies.

--- a/connect.py
+++ b/connect.py
@@ -38,6 +38,9 @@ outline_client = AsyncOutline(
     base_url=os.getenv('OUTLINE_URL')
 )
 
+# Configuration for automatic group creation
+AUTO_CREATE_GROUPS = os.getenv('AUTO_CREATE_GROUPS', False).lower() == 'true'
+
 @app.get("/")
 def root():
     return({'status': 'running'})
@@ -84,19 +87,6 @@ async def sync(request: Request):
     authentik_groups = helpers.authentik.get_authentik_groups()
     outline_groups = await helpers.outline.get_outline_groups()
 
-    matched_groups = []
-
-    user_authentik_groups = []
-    user_outline_groups = []
-
-    # Matching groups together by name
-    for name in authentik_groups:
-        for outline_group in outline_groups:
-            if name in outline_group:
-                matched_groups.append(outline_group)
-                break
-    logger.info(f"Matched {len(matched_groups)} groups")
-
     # Getting Outline user's email
     user_response = await outline_client.post(path='/api/users.info', cast_to=httpx.Response, body={'id': outline_id})
     user = json.loads(await user_response.aread())
@@ -106,36 +96,58 @@ async def sync(request: Request):
     with authentik_client.ApiClient(authentik_config) as api_client:
         api_instance = authentik_client.CoreApi(api_client)
         authentik_user = api_instance.core_users_list(email=email).results[0]
-        for obj in authentik_user.groups_obj:
-            # Only adding user group if it is in matched_groups
-            if obj.name in [list(kv.keys())[0] for kv in matched_groups]:
-                user_authentik_groups.append(obj.name)
-    logger.debug(f"Got {len(user_authentik_groups)} user groups from Authentik")
+        user_authentik_groups = [obj.name for obj in authentik_user.groups_obj]
 
-    # Getting Outline user's groups
+    logger.debug(f"User is member of {len(user_authentik_groups)} groups in Authentik")
+
+    # Create a map of outline groups for easier lookup
+    outline_groups_map = {}
     for group in outline_groups:
-        group_id = list(group.values())[0]
-        membership = await helpers.outline.get_group_membership(group_id, outline_id, user['data']['name'])
-        if membership:
-            user_outline_groups.append(group_id)
-
-    logger.debug(f"Got {len(user_outline_groups)} user groups from Outline")
-
-    # Adding user to matched groups, removing user from unmatched groups
-    for group in matched_groups:
         group_name = list(group.keys())[0]
         group_id = list(group.values())[0]
+        outline_groups_map[group_name] = group_id
 
-        if group_name in user_authentik_groups:
-            if group_id not in user_outline_groups: # User is in Authentik group but not in Outline group, add
-                await helpers.outline.add_user_to_group(group_id, outline_id)
-            else: # User is in both Authentik and Outline groups already
-                logger.debug(f"User is already in group {group_id}, not adding")
-        else:
-            if group_id in user_outline_groups: # User is in Outline group but not in Authentik group, remove
-                await helpers.outline.remove_user_from_group(group_id, outline_id)
-            else: # User is not in either Authentik or Outline group
-                logger.debug(f"User is already not in group {group_id}, not removing")
+    # Process each Authentik group
+    for authentik_group_name in authentik_groups:
+        # Check if user is member of this group in Authentik
+        user_is_member_in_authentik = authentik_group_name in user_authentik_groups
+        
+        # Check if user is member of this group in Outline
+        user_is_member_in_outline = False
+        outline_group_id = outline_groups_map.get(authentik_group_name)
+        if outline_group_id:
+            membership = await helpers.outline.get_group_membership(outline_group_id, outline_id, user['data']['name'])
+            user_is_member_in_outline = membership
+        
+        # User is NOT member in Authentik but IS member in Outline -> Remove from Outline
+        if not user_is_member_in_authentik and user_is_member_in_outline:
+            logger.info(f"Removing user from Outline group '{authentik_group_name}'")
+            await helpers.outline.remove_user_from_group(outline_group_id, outline_id)
+        
+        # User IS member in Authentik
+        elif user_is_member_in_authentik:
+            # Check if group exists in Outline
+            if not outline_group_id:
+                # Group does not exist in Outline and auto-creation is enabled -> create it
+                if AUTO_CREATE_GROUPS:
+                    logger.info(f"Creating missing group '{authentik_group_name}' in Outline")
+                    create_status, new_group_id = await helpers.outline.create_group(authentik_group_name)
+                    if create_status == 200 and new_group_id:
+                        outline_group_id = new_group_id
+                        outline_groups_map[authentik_group_name] = outline_group_id
+                    else:
+                        logger.error(f"Failed to create group '{authentik_group_name}' in Outline")
+                        continue
+                else: # Group does not exist in Outline and auto-creation is disabled
+                    logger.debug(f"Group '{authentik_group_name}' doesn't exist in Outline and auto-creation is disabled")
+                    continue
+            
+            # Add user to group if not already member
+            if not user_is_member_in_outline:
+                logger.info(f"Adding user to Outline group '{authentik_group_name}'")
+                await helpers.outline.add_user_to_group(outline_group_id, outline_id)
+            else:
+                logger.debug(f"User is already member of group '{authentik_group_name}' in Outline")
 
     logger.info("Sync complete!")
     return({'status': 'success'})

--- a/helpers/outline.py
+++ b/helpers/outline.py
@@ -51,3 +51,22 @@ async def remove_user_from_group(group_id, user_id):
     else:
         logger.error(f"Failed to remove user {user_id} from group {group_id}")
     return(response.status_code)
+
+async def create_group(group_name):
+    response = await outline_client.post(path='/api/groups.create', cast_to=httpx.Response, body={'name': group_name})
+    if response.status_code == 200:
+        logger.debug(f"Created group {group_name}")
+        response_data = json.loads(await response.aread())
+        group_id = response_data['data']['id']
+        return (response.status_code, group_id)
+    else:
+        logger.error(f"Failed to create group {group_name}")
+        return (response.status_code, None)
+
+async def delete_group(group_id):
+    response = await outline_client.post(path='/api/groups.delete', cast_to=httpx.Response, body={'id': group_id})
+    if response.status_code == 200:
+        logger.debug(f"Deleted group {group_id}")
+    else:
+        logger.error(f"Failed to delete group {group_id}")
+    return(response.status_code)


### PR DESCRIPTION
I’ve implemented the feature to automatically create groups from Authentik if they don’t already exist in Outline (resolves #2).
This behavior is **optional** and can be enabled by setting the environment variable `AUTO_CREATE_GROUPS=true`.
A group is created only if a user is a member of it, so this helps keep the list of groups clean and avoids unnecessary clutter.

I’ve also slightly reorganized the group comparison logic — functionally it’s unchanged, but I believe it’s now a bit clearer and easier to follow.

Open to any feedback or suggestions!